### PR TITLE
Fixed typo in webgl-utils.js createUniformSetters of 'tetxure' => 'te…

### DIFF
--- a/webgl/resources/webgl-utils.js
+++ b/webgl/resources/webgl-utils.js
@@ -501,7 +501,7 @@
             gl.uniform1iv(location, units);
             textures.forEach(function(texture, index) {
               gl.activeTexture(gl.TEXTURE0 + units[index]);
-              gl.bindTexture(bindPoint, tetxure);
+              gl.bindTexture(bindPoint, texture);
             });
           };
         }(getBindPointForSamplerType(gl, type), units);


### PR DESCRIPTION
…xture' that would cause problems binding arrays of SAMPLER_2D or SAMPLER_CUBE.