### PR TITLE
supply missing " and correct spelling of "concatenations".

### DIFF
--- a/webgl/lessons/webgl-fundamentals.html
+++ b/webgl/lessons/webgl-fundamentals.html
@@ -272,8 +272,8 @@ is concerned.</p>
 <p>
 We can use this feature to store shaders in script tags. This is convenient
 because if we couldn't do this we'd have to either write really ugly
-string concatinations like</p>
-<pre class="prettyprint>
+string concatenations like</p>
+<pre class="prettyprint">
   var shaderSource =
     "void main() {\n" +
     "  gl_FragColor = vec4(1,0,0,1);\n" +

--- a/webgl/lessons/webgl-fundamentals.md
+++ b/webgl/lessons/webgl-fundamentals.md
@@ -217,8 +217,8 @@ is concerned.</p>
 <p>
 We can use this feature to store shaders in script tags. This is convenient
 because if we couldn't do this we'd have to either write really ugly
-string concatinations like</p>
-<pre class="prettyprint>
+string concatenations like</p>
+<pre class="prettyprint">
   var shaderSource =
     "void main() {\n" +
     "  gl_FragColor = vec4(1,0,0,1);\n" +


### PR DESCRIPTION
The [page's display](http://webglfundamentals.org/webgl/lessons/webgl-fundamentals.html) is broken due to a missing `"` and there's also a typo.