### PR TITLE
fixed relative url issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated from webgl/lessons/index.md. Do not edited directly -->
+<!-- this file is auto-generated from webgl\lessons\index.md. Do not edited directly -->
 <!--
 Copyright 2012, Gregg Tavares.
 All rights reserved.

--- a/webgl/lessons/fr/index.html
+++ b/webgl/lessons/fr/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated from webgl/lessons/fr/index.md. Do not edited directly -->
+<!-- this file is auto-generated from webgl\lessons\fr\index.md. Do not edited directly -->
 <!--
 Copyright 2012, Gregg Tavares.
 All rights reserved.

--- a/webgl/lessons/fr/webgl-2d-matrices.html
+++ b/webgl/lessons/fr/webgl-2d-matrices.html
@@ -71,9 +71,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 <p>Dans les 3 derniers posts on a parlé des <a href="webgl-2d-translation.html">translations</a>, <a href="webgl-2d-rotation.html">rotations</a> et <a href="webgl-2d-scale.html">changement d&#39;échelle</a>. Translation, rotation et changement d&#39;échelle sont les 3 types de &#39;transformation&#39;. Chacune de ces transformations demande des changements dans le shader de vertex et on a vu que le résultat dépend de l&#39;ordre dans lequel elles sont appliquées : certaines sont non-commutatives. Dans le <a href="webgl-2d-scale.html">précédent exemple</a> on a changé l&#39;échelle, puis tourné et déplacé. Dans un autre ordre on aurait eu un résultat différent.
 <!--more-->
 Par exemple, voici la suite de transformations suivantes : échelle de (2,1), rotation de 30 degrés et translation de (100, 0) :</p>
-<p><img src="../resources/f-scale-rotation-translation.svg" class="webgl_center" width="400" /></p>
+<p><img src="../../resources/f-scale-rotation-translation.svg" class="webgl_center" width="400" /></p>
 <p>Et voici un déplacement de (100,0) suivi d&#39;une rotation de 30 degrés et un changement d&#39;échelle de (2,1) :</p>
-<p><img src="../resources/f-translation-rotation-scale.svg" class="webgl_center" width="400" /></p>
+<p><img src="../../resources/f-translation-rotation-scale.svg" class="webgl_center" width="400" /></p>
 <p>Les résultats sont complètement différents. Pire, si on veut aboutir au second exemple il nous faut écrire un autre shader qui applique les transformations dans l&#39;ordre qu&#39;on souhaite.</p>
 <p>Eh bien, des personnes plus futées que moi ont réalisé qu&#39;on peut faire la même chose avec des matrices. Pour la 2D on utilise une matrice carrée d&#39;ordre 3 (3x3). Une matrice 3x3 est comme une grille de 9 cases :</p>
 <p><style>.glocal-center { text-align: center; } .glocal-center-content { margin-left: auto; margin-right: auto; } .glocal-mat td, .glocal-b { border: 1px solid black; text-align: left;} .glocal-mat td { text-align: center; } .glocal-border { border: 1px solid black; } .glocal-sp { text-align: right !important;  width: 8em;} .glocal-blk { color: black; background-color: black; } .glocal-left { text-align: left; } .glocal-right { text-align: right; }</style></p>

--- a/webgl/lessons/fr/webgl-2d-matrices.md
+++ b/webgl/lessons/fr/webgl-2d-matrices.md
@@ -7,11 +7,11 @@ Dans les 3 derniers posts on a parlé des <a href="webgl-2d-translation.html">tr
 <!--more-->
 Par exemple, voici la suite de transformations suivantes : échelle de (2,1), rotation de 30 degrés et translation de (100, 0) :
 
-<img src="../resources/f-scale-rotation-translation.svg" class="webgl_center" width="400" />
+<img src="../../resources/f-scale-rotation-translation.svg" class="webgl_center" width="400" />
 
 Et voici un déplacement de (100,0) suivi d'une rotation de 30 degrés et un changement d'échelle de (2,1) :
 
-<img src="../resources/f-translation-rotation-scale.svg" class="webgl_center" width="400" />
+<img src="../../resources/f-translation-rotation-scale.svg" class="webgl_center" width="400" />
 
 Les résultats sont complètement différents. Pire, si on veut aboutir au second exemple il nous faut écrire un autre shader qui applique les transformations dans l'ordre qu'on souhaite.
 

--- a/webgl/lessons/fr/webgl-2d-rotation.html
+++ b/webgl/lessons/fr/webgl-2d-rotation.html
@@ -127,7 +127,7 @@ void main() {
 <pre><code>rotatedX = a_position.x * u_rotation.y + a_position.y * u_rotation.x;
 rotatedY = a_position.y * u_rotation.y - a_position.x * u_rotation.x;
 </code></pre><p>Disons que vous avez un rectangle et que vous voulez le tourner. Avant, le coin en haut à droite est à (3,9). Choisissons un point sur le cercle qui soit à 30 degrés plus loin dans le sens des aiguilles d&#39;une montre, depuis disons, midi.</p>
-<p><img src="../resources/rotate-30.png" class="webgl_center" /></p>
+<p><img src="../../resources/rotate-30.png" class="webgl_center" /></p>
 <p>La position sur le cercle ici est à (0.50,0.87)</p>
 <pre class="webgl_center">
    3.0 * 0.87 + 9.0 * 0.50 = 7.1
@@ -135,9 +135,9 @@ rotatedY = a_position.y * u_rotation.y - a_position.x * u_rotation.x;
 </pre>
 
 <p>Exctement ce qu&#39;on voulait</p>
-<p><img src="../resources/rotation-drawing.svg" width="500" class="webgl_center"/></p>
+<p><img src="../../resources/rotation-drawing.svg" width="500" class="webgl_center"/></p>
 <p>Pour 60 degrees dans le même sens</p>
-<p><img src="../resources/rotate-60.png" class="webgl_center" /></p>
+<p><img src="../../resources/rotate-60.png" class="webgl_center" /></p>
 <p>La position sur le cercle est (0.87,0.50).</p>
 <pre class="webgl_center">
    3.0 * 0.50 + 9.0 * 0.87 = 9.3

--- a/webgl/lessons/fr/webgl-2d-rotation.md
+++ b/webgl/lessons/fr/webgl-2d-rotation.md
@@ -68,7 +68,7 @@ Pourquoi ça fonctionne ? Regardez les opérations :
 
 Disons que vous avez un rectangle et que vous voulez le tourner. Avant, le coin en haut à droite est à (3,9). Choisissons un point sur le cercle qui soit à 30 degrés plus loin dans le sens des aiguilles d'une montre, depuis disons, midi.
 
-<img src="../resources/rotate-30.png" class="webgl_center" />
+<img src="../../resources/rotate-30.png" class="webgl_center" />
 
 La position sur le cercle ici est à (0.50,0.87)
 
@@ -79,11 +79,11 @@ La position sur le cercle ici est à (0.50,0.87)
 
 Exctement ce qu'on voulait
 
-<img src="../resources/rotation-drawing.svg" width="500" class="webgl_center"/>
+<img src="../../resources/rotation-drawing.svg" width="500" class="webgl_center"/>
 
 Pour 60 degrees dans le même sens
 
-<img src="../resources/rotate-60.png" class="webgl_center" />
+<img src="../../resources/rotate-60.png" class="webgl_center" />
 
 La position sur le cercle est (0.87,0.50).
 

--- a/webgl/lessons/fr/webgl-2d-translation.html
+++ b/webgl/lessons/fr/webgl-2d-translation.html
@@ -105,7 +105,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 </p>
 <p>Génial. Maintenant imaginons qu&#39;on veuille faire la même chose avec une forme plus compliquée...</p>
 <p>Disons qu&#39;on veut dessiner un &#39;F&#39; composé de 6 triangles comme ceci</p>
-<p><img src="../resources/polygon-f.svg" width="200" height="270" class="webgl_center"></p>
+<p><img src="../../resources/polygon-f.svg" width="200" height="270" class="webgl_center"></p>
 <p>En suivant la même logique il nous faudrait changer <code>creerRectangle</code> pour quelque chose dans ce style :</p>
 <pre class="prettyprint showlinemods">
 // Remplit le tampon avec les valeurs qui définissent un 'F'.

--- a/webgl/lessons/fr/webgl-2d-translation.md
+++ b/webgl/lessons/fr/webgl-2d-translation.md
@@ -40,7 +40,7 @@ Génial. Maintenant imaginons qu'on veuille faire la même chose avec une forme 
 
 Disons qu'on veut dessiner un 'F' composé de 6 triangles comme ceci
 
-<img src="../resources/polygon-f.svg" width="200" height="270" class="webgl_center">
+<img src="../../resources/polygon-f.svg" width="200" height="270" class="webgl_center">
 
 En suivant la même logique il nous faudrait changer `creerRectangle` pour quelque chose dans ce style :
 

--- a/webgl/lessons/fr/webgl-3d-lighting-point.html
+++ b/webgl/lessons/fr/webgl-3d-lighting-point.html
@@ -174,7 +174,7 @@ void main() {
 </p>
 <p>Maintenant qu&#39;on a notre lumière point on peut ajouter quelque chose qu&#39;on appelle l&#39;éclairage spéculaire. </p>
 <p>Si on regarde un objet dans le vrai monde, s&#39;il est vaguement brillant et qu&#39;il reflète une lumière directement dans notre direction, ça fait comme un miroir</p>
-<p><img class="webgl_center" src="resources/specular-highlights.jpg" /></p>
+<p><img class="webgl_center" src="../../resources/specular-highlights.jpg" /></p>
 <p>On peut simuler cet effet en calculant si la lumière se reflète dans notre direction. Le <em>produit scalaire</em> va là aussi nous aider.</p>
 <p>Que doit-on faire ? Réfléchissons. La lumière se réfléchit avec le même angle par lequel elle atteint la surface. Donc si la direction entre la surface et la lumière est la réflexion exacte de la direction de la surface à l&#39;observateur alors la réflexion est maximale.</p>
 <p><div>

--- a/webgl/lessons/fr/webgl-3d-lighting-point.md
+++ b/webgl/lessons/fr/webgl-3d-lighting-point.md
@@ -128,7 +128,7 @@ Maintenant qu'on a notre lumière point on peut ajouter quelque chose qu'on appe
 
 Si on regarde un objet dans le vrai monde, s'il est vaguement brillant et qu'il reflète une lumière directement dans notre direction, ça fait comme un miroir
 
-<img class="webgl_center" src="resources/specular-highlights.jpg" />
+<img class="webgl_center" src="../../resources/specular-highlights.jpg" />
 
 On peut simuler cet effet en calculant si la lumière se reflète dans notre direction. Le *produit scalaire* va là aussi nous aider.
 

--- a/webgl/lessons/fr/webgl-3d-orthographic.html
+++ b/webgl/lessons/fr/webgl-3d-orthographic.html
@@ -256,7 +256,7 @@ elles se simplifient comme avant :</p>
 </div>
 
 <p>Ce qui donne ces rotations.</p>
-<iframe class="external_diagram" src="resources/axis-diagram.html" style="width: 540px; height: 240px;"></iframe>
+<iframe class="external_diagram" src="../../resources/axis-diagram.html" style="width: 540px; height: 240px;"></iframe>
 
 <p>On doit aussi changer la fonction de projection. Voici l&#39;ancienne :</p>
 <pre class="prettyprint showlinemods">
@@ -428,7 +428,7 @@ le résultat qu&#39;on espère. </p>
 <p>Les triangles en WebGL ont un concept directionnel, on peut dire qu&#39;on les regarde 
 par devant ou par derrière. Un triangle vu par devant a ses vertices qui vont dans le 
 sens des aiguilles d&#39;une montre, le contraire vu par derrière.</p>
-<p><img src="resources/triangle-winding.svg" class="webgl_center" width="400" /></p>
+<p><img src="../../resources/triangle-winding.svg" class="webgl_center" width="400" /></p>
 <p>WebGL peut ne dessiner que les triangles vus par devant ou que ceux vus par derrière. 
 On peut activer cette possibilité avec </p>
 <pre class="prettyprint showlinemods">

--- a/webgl/lessons/fr/webgl-3d-orthographic.md
+++ b/webgl/lessons/fr/webgl-3d-orthographic.md
@@ -206,7 +206,7 @@ rotation X
 
 Ce qui donne ces rotations.
 
-<iframe class="external_diagram" src="resources/axis-diagram.html" style="width: 540px; height: 240px;"></iframe>
+<iframe class="external_diagram" src="../../resources/axis-diagram.html" style="width: 540px; height: 240px;"></iframe>
 
 On doit aussi changer la fonction de projection. Voici l'ancienne :
 
@@ -381,7 +381,7 @@ Les triangles en WebGL ont un concept directionnel, on peut dire qu'on les regar
 par devant ou par derrière. Un triangle vu par devant a ses vertices qui vont dans le 
 sens des aiguilles d'une montre, le contraire vu par derrière.
 
-<img src="resources/triangle-winding.svg" class="webgl_center" width="400" />
+<img src="../../resources/triangle-winding.svg" class="webgl_center" width="400" />
 
 WebGL peut ne dessiner que les triangles vus par devant ou que ceux vus par derrière. 
 On peut activer cette possibilité avec 

--- a/webgl/lessons/fr/webgl-3d-perspective.html
+++ b/webgl/lessons/fr/webgl-3d-perspective.html
@@ -76,7 +76,7 @@ C&#39;était ce qu&#39;on appelle des vues &quot;orthographiques&quot; qui ont l
 veulent en général quand on dit &quot;3D&quot;.</p>
 <p>Pour ça on a besoin de perspective. Qu&#39;est-ce que la perspective ? C&#39;est ce qui fait que ce qui est loin
  apparaît plus petit.</p>
-<p><img class="webgl_center" width="500" src="resources/perspective-example.svg" /></p>
+<p><img class="webgl_center" width="500" src="../../resources/perspective-example.svg" /></p>
 <p>En voyant cet exemple on voit que ce qui est à plus grande distance est dessiné en plus petit. Avec notre exemple 
 habituel, une façon simple d&#39;implémenter ceci serait de diviser les composantes X et Y de l&#39;espace de projection, par Z.</p>
 <p>Pensez-y comme ça : si on a une ligne de (10,15) à (20,15) elle a 10 unités de long. 
@@ -150,7 +150,7 @@ void main() {
 
 </p>
 <p>Si ce n&#39;est pas clair la valeur du &quot;facteurDeFuite&quot; peut être changée entre 1 et 0 sur le slider pour voir comment les choses étaient avant d&#39;appliquer notre division par Z, c&#39;est-à-dire en orthographique.</p>
-<p><img class="webgl_center" src="resources/orthographic-vs-perspective.png" /></p>
+<p><img class="webgl_center" src="../../resources/orthographic-vs-perspective.png" /></p>
 <div class="webgl_center">orthographique vs perspective</div>
 
 <p>Il se trouve que WebGL prend les valeurs x, y, z, w assignées à gl_Position dans notre shader de vertex 
@@ -319,7 +319,7 @@ function matriceZversW(facteurDeFuite) {
 </p>
 <p>Tout ça pour montrer que diviser par Z donne la perspective et que WebGL fait ça automatiquement.</p>
 <p>Mais il reste quelques soucis. Si on met Z à -100 on se retrouve avec quelque chose comme l&#39;animation ci-dessous</p>
-<p><img class="webgl_center" src="resources/z-clipping.gif" style="border: 1px solid black;" /></p>
+<p><img class="webgl_center" src="../../resources/z-clipping.gif" style="border: 1px solid black;" /></p>
 <p>Quest-ce qu&#39;il se passe ? Pourquoi le F disparaît ? Tout comme WebGL tronque le X et le Y au-delà de -1 et +1 il tronque aussi le Z. 
 Ce qu&#39;on voit c&#39;est le Z &lt; -1. </p>
 <p>Je pourrais entrer dans les détails pour résoudre ça mais <a href="http://stackoverflow.com/a/28301213/128511">vous pouvez déduire la solution</a> comme on l&#39;a fait dans les projections 2D. On a besoin de prendre Z, ajouter du déplacement et du changement d&#39;échelle, et on peut ajuster tout ce qu&#39;on veut entre -1 et +1. </p>

--- a/webgl/lessons/fr/webgl-3d-perspective.md
+++ b/webgl/lessons/fr/webgl-3d-perspective.md
@@ -13,7 +13,7 @@ veulent en général quand on dit "3D".
 Pour ça on a besoin de perspective. Qu'est-ce que la perspective ? C'est ce qui fait que ce qui est loin
  apparaît plus petit.
 
-<img class="webgl_center" width="500" src="resources/perspective-example.svg" />
+<img class="webgl_center" width="500" src="../../resources/perspective-example.svg" />
 
 En voyant cet exemple on voit que ce qui est à plus grande distance est dessiné en plus petit. Avec notre exemple 
 habituel, une façon simple d'implémenter ceci serait de diviser les composantes X et Y de l'espace de projection, par Z.
@@ -95,7 +95,7 @@ Résultat :
 
 Si ce n'est pas clair la valeur du "facteurDeFuite" peut être changée entre 1 et 0 sur le slider pour voir comment les choses étaient avant d'appliquer notre division par Z, c'est-à-dire en orthographique.
 
-<img class="webgl_center" src="resources/orthographic-vs-perspective.png" />
+<img class="webgl_center" src="../../resources/orthographic-vs-perspective.png" />
 <div class="webgl_center">orthographique vs perspective</div>
 
 Il se trouve que WebGL prend les valeurs x, y, z, w assignées à gl_Position dans notre shader de vertex 
@@ -275,7 +275,7 @@ Tout ça pour montrer que diviser par Z donne la perspective et que WebGL fait �
 
 Mais il reste quelques soucis. Si on met Z à -100 on se retrouve avec quelque chose comme l'animation ci-dessous
 
-<img class="webgl_center" src="resources/z-clipping.gif" style="border: 1px solid black;" />
+<img class="webgl_center" src="../../resources/z-clipping.gif" style="border: 1px solid black;" />
 
 Quest-ce qu'il se passe ? Pourquoi le F disparaît ? Tout comme WebGL tronque le X et le Y au-delà de -1 et +1 il tronque aussi le Z. 
 Ce qu'on voit c'est le Z < -1. 

--- a/webgl/lessons/fr/webgl-fundamentals.html
+++ b/webgl/lessons/fr/webgl-fundamentals.html
@@ -88,8 +88,8 @@ gl.useProgram(programme);
 // Création d&#39;un pointeur pour les données de vertex
 var emplacementPosition = gl.getAttribLocation(programme, &quot;a_position&quot;);
 
-// Créé un tampon et ajoute un rectangle avec des données en espace de projection déjà préparées
-// (un rectangle = 2 triangle)
+// Crée un tampon et ajoute un rectangle avec des données en espace de projection déjà préparées
+// (un rectangle = 2 triangles)
 var tampon = gl.createBuffer();
 gl.bindBuffer(gl.ARRAY_BUFFER, tampon);
 gl.bufferData(
@@ -160,7 +160,7 @@ void main() {
 var emplacementResolution = gl.getUniformLocation(program, &quot;u_resolution&quot;);
 gl.uniform2f(emplacementResolution, canvas.width, canvas.height);
 
-// créé un rectangle qui va de 10,20 à 80,30 en pixels
+// crée un rectangle qui va de 10,20 à 80,30 en pixels
 gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([
     10, 20,
     80, 20,
@@ -203,7 +203,7 @@ void main() {
 </code></pre><p>Et voici le nouveau code qui rend 50 rectangles disposés au hasard et avec des couleurs aléatoires.</p>
 <pre><code>  var emplacementCouleur = gl.getUniformLocation(programme, &quot;u_color&quot;);
   ...
-  // Créé un tampon
+  // Crée un tampon
   var tampon = gl.createBuffer();
   gl.bindBuffer(gl.ARRAY_BUFFER, tampon);
   gl.enableVertexAttribArray(positionLocation);
@@ -211,7 +211,7 @@ void main() {
 
   // Rend 50 rectangles au hasard avec couleurs aléatoires.
   for (var ii = 0; ii &lt; 50; ++ii) {
-    // Créé un rectangle au hasard
+    // Crée un rectangle au hasard
     creerRectangle(
         gl, entierAleatoir(300), entierAleatoir(300), entierAleatoir(300), entierAleatoir(300));
 

--- a/webgl/lessons/fr/webgl-fundamentals.md
+++ b/webgl/lessons/fr/webgl-fundamentals.md
@@ -26,8 +26,8 @@ Voici un simple exemple pour illustrer un code WebGL dans sa forme la plus simpl
     // Création d'un pointeur pour les données de vertex
     var emplacementPosition = gl.getAttribLocation(programme, "a_position");
 
-    // Créé un tampon et ajoute un rectangle avec des données en espace de projection déjà préparées
-    // (un rectangle = 2 triangle)
+    // Crée un tampon et ajoute un rectangle avec des données en espace de projection déjà préparées
+    // (un rectangle = 2 triangles)
     var tampon = gl.createBuffer();
     gl.bindBuffer(gl.ARRAY_BUFFER, tampon);
     gl.bufferData(
@@ -103,7 +103,7 @@ Maintenant on peut changer nos données en pixels
     var emplacementResolution = gl.getUniformLocation(program, "u_resolution");
     gl.uniform2f(emplacementResolution, canvas.width, canvas.height);
 
-    // créé un rectangle qui va de 10,20 à 80,30 en pixels
+    // crée un rectangle qui va de 10,20 à 80,30 en pixels
     gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([
         10, 20,
         80, 20,
@@ -147,7 +147,7 @@ Et voici le nouveau code qui rend 50 rectangles disposés au hasard et avec des 
 
       var emplacementCouleur = gl.getUniformLocation(programme, "u_color");
       ...
-      // Créé un tampon
+      // Crée un tampon
       var tampon = gl.createBuffer();
       gl.bindBuffer(gl.ARRAY_BUFFER, tampon);
       gl.enableVertexAttribArray(positionLocation);
@@ -155,7 +155,7 @@ Et voici le nouveau code qui rend 50 rectangles disposés au hasard et avec des 
 
       // Rend 50 rectangles au hasard avec couleurs aléatoires.
       for (var ii = 0; ii < 50; ++ii) {
-        // Créé un rectangle au hasard
+        // Crée un rectangle au hasard
         creerRectangle(
             gl, entierAleatoir(300), entierAleatoir(300), entierAleatoir(300), entierAleatoir(300));
 

--- a/webgl/lessons/fr/webgl-how-it-works.html
+++ b/webgl/lessons/fr/webgl-how-it-works.html
@@ -76,7 +76,7 @@ la première partie. </p>
 <p>Quand vous appelez</p>
 <pre><code>gl.drawArrays(gl.TRIANGLE, 0, 9);
 </code></pre><p>Le 9 ici signifie &quot;il y a 9 vertices à traiter&quot; donc voilà 9 vertices rendus.</p>
-<p><img src="resources/vertex-shader-anim.gif" class="webgl_center" /></p>
+<p><img src="../../resources/vertex-shader-anim.gif" class="webgl_center" /></p>
 <p>Sur la gauche il y a les données fournies. Le shader de vertex est une fonction que vous écrivez en 
 <a href="webgl-shaders-and-glsl.html">GLSL</a>. Il est appelé une fois pour chaque vertex.
 Vous écrivez quelques opérations et renseignez la variable <code>gl_Position</code> avec une valeur

--- a/webgl/lessons/fr/webgl-how-it-works.md
+++ b/webgl/lessons/fr/webgl-how-it-works.md
@@ -14,7 +14,7 @@ Quand vous appelez
 
 Le 9 ici signifie "il y a 9 vertices à traiter" donc voilà 9 vertices rendus.
 
-<img src="resources/vertex-shader-anim.gif" class="webgl_center" />
+<img src="../../resources/vertex-shader-anim.gif" class="webgl_center" />
 
 Sur la gauche il y a les données fournies. Le shader de vertex est une fonction que vous écrivez en 
 [GLSL](webgl-shaders-and-glsl.html). Il est appelé une fois pour chaque vertex.

--- a/webgl/lessons/index.html
+++ b/webgl/lessons/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated from webgl/lessons/index.md. Do not edited directly -->
+<!-- this file is auto-generated from webgl\lessons\index.md. Do not edited directly -->
 <!--
 Copyright 2012, Gregg Tavares.
 All rights reserved.

--- a/webgl/lessons/pl/index.html
+++ b/webgl/lessons/pl/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated from webgl/lessons/pl/index.md. Do not edited directly -->
+<!-- this file is auto-generated from webgl\lessons\pl\index.md. Do not edited directly -->
 <!--
 Copyright 2012, Gregg Tavares.
 All rights reserved.

--- a/webgl/lessons/webgl-3d-orthographic.html
+++ b/webgl/lessons/webgl-3d-orthographic.html
@@ -324,7 +324,7 @@ for <code>depth</code> it will be <code>-depth / 2</code> to <code>+depth / 2</c
 hard to see any 3D.  To fix that let&#39;s expand the geometry to 3D.  Our
 current F is made of 3 rectangles, 2 triangles each.  To make it 3D will
 require a total of 16 rectangles.  That&#39;s quite a few to list out here.
-16 rectangles <em> 2 triangles per rectangle </em> 3 vertices per triangle is 96
+16 rectangles with 2 triangles per rectangle and 3 vertices per triangle is 96
 vertices.  If you want to see all of them view the source of the sample.</p>
 <p>We have to draw more vertices so</p>
 <pre class="prettyprint showlinemods">

--- a/webgl/lessons/webgl-3d-orthographic.md
+++ b/webgl/lessons/webgl-3d-orthographic.md
@@ -275,7 +275,7 @@ The first problem we have is that our geometry is a flat F which makes it
 hard to see any 3D.  To fix that let's expand the geometry to 3D.  Our
 current F is made of 3 rectangles, 2 triangles each.  To make it 3D will
 require a total of 16 rectangles.  That's quite a few to list out here.
-16 rectangles * 2 triangles per rectangle * 3 vertices per triangle is 96
+16 rectangles with 2 triangles per rectangle and 3 vertices per triangle is 96
 vertices.  If you want to see all of them view the source of the sample.
 
 We have to draw more vertices so


### PR DESCRIPTION
Sometimes links are written in html inside md files, I did not change that in the files inside the `fr` folder. Relative urls were not correct in the end. 

I also changed the syntax for a multiplication inside the '3D orthographic' lesson which after the build ended with `<em>` tags.