### PR TITLE
fix typo `stide` -> `stride` in webgl-fundamentals lesson psudeocode …

### DIFF
--- a/webgl/lessons/ja/webgl-fundamentals.md
+++ b/webgl/lessons/ja/webgl-fundamentals.md
@@ -95,7 +95,7 @@ GLSLの代わりにJavaScriptで書かれて起動したらことように動く
       var size = 4;
       for (var i = 0; i < count; ++i) {
          // positionBufferから次の４つの数値をa_positionの属性に読み込み
-         attributes.a_position = positionBuffer.slice((offset + i) * stide, size);
+         attributes.a_position = positionBuffer.slice((offset + i) * stride, size);
 
          runVertexShader();　// ⇐　頂点シェーダーを呼び出す！
          ...

--- a/webgl/lessons/ru/webgl-fundamentals.md
+++ b/webgl/lessons/ru/webgl-fundamentals.md
@@ -97,7 +97,7 @@ WebGL затем может растеризовать различные при
       var size = 4;
       for (var i = 0; i < count; ++i) {
          // копировать следующие 4 значения из positionBuffer в атрибут a_position
-         attributes.a_position = positionBuffer.slice((offset + i) * stide, size);
+         attributes.a_position = positionBuffer.slice((offset + i) * stride, size);
          runVertexShader();
          ...
          doSomethingWith_gl_Position();

--- a/webgl/lessons/webgl-fundamentals.md
+++ b/webgl/lessons/webgl-fundamentals.md
@@ -97,7 +97,7 @@ you could imagine it would be used like this
       var size = 4;
       for (var i = 0; i < count; ++i) {
          // copy the next 4 values from positionBuffer to the a_position attribute
-         attributes.a_position = positionBuffer.slice((offset + i) * stide, size);
+         attributes.a_position = positionBuffer.slice((offset + i) * stride, size);
          runVertexShader();
          ...
          doSomethingWith_gl_Position();


### PR DESCRIPTION
…variable

reference.