### PR TITLE
Fix deadlink.

### DIFF
--- a/webgl/lessons/ja/webgl-image-processing.md
+++ b/webgl/lessons/ja/webgl-image-processing.md
@@ -185,8 +185,9 @@ WebGLはテクスチャを参照する際、0.0から1.0の値を取る「テク
 「1.0」を比較して「より大きい方」で割る。
 「ぼかし」の際に行なった「平均値を求める」仕組みの拡張と考えればよいだろう。
 
-ここでは「畳み込み行列」についてこれ以上の説明はしないが、興味があれば
-[この記事](http://docs.gimp.org/en/plug-in-convmatrix.html)([日本語版](https://docs.gimp.org/ja/plug-in-convmatrix.html))がわかりやすいので、参考にするとよいだろう。
+「畳み込み行列」について、ここではこれ以上の説明はしないが、興味があれば
+[わかりやすい記事がある](https://docs.gimp.org/2.10/en/gimp-filter-convolution-matrix.html)
+([日本語版](https://docs.gimp.org/2.10/ja/gimp-filter-convolution-matrix.html))ので、参考にするとよいだろう。
 また、[この記事](http://www.codeproject.com/KB/graphics/ImageConvolution.aspx)では
 「畳み込み行列」をC++で実装したコードを見ることができる。
 

--- a/webgl/lessons/webgl-image-processing.md
+++ b/webgl/lessons/webgl-image-processing.md
@@ -166,7 +166,7 @@ to do a bunch of common image processing. In this case we'll use a 3x3 kernel.
 A convolution kernel is just a 3x3 matrix where each entry in the matrix represents
 how much to multiply the 8 pixels around the pixel we are rendering. We then divide
 the result by the weight of the kernel (the sum of all values in the kernel) or 1.0,
-whichever is greater. [Here's a pretty good article on it](http://docs.gimp.org/en/plug-in-convmatrix.html).
+whichever is greater. [Here's a pretty good article on it](https://docs.gimp.org/2.10/en/gimp-filter-convolution-matrix.html).
 And [here's another article showing some actual code if you were to write this by
 hand in C++](http://www.codeproject.com/KB/graphics/ImageConvolution.aspx).
 


### PR DESCRIPTION
Links to "convolution kernel(convolution matrix)" articles in "GIMP document" site seems dead.

「畳み込み行列の説明」について、GIMPのサイトの構造が変更されてリンク切れとなっていたので、リンク先を変更しました。

新しいリンク先がベストな選択かどうか、判断が難しいですが、「GIMP公式と思われるページ( https://www.gimp.org/ )からリンクを辿ることができる」ページを選びました。