### PR TITLE
Fix escaped angle brackets in shader code example in 2D Translation page

### DIFF
--- a/webgl/lessons/ja/webgl-2d-scale.md
+++ b/webgl/lessons/ja/webgl-2d-scale.md
@@ -10,7 +10,7 @@ Description: WebGLの二次元拡大と縮小し方
 [前回のサンプル](webgl-2d-rotation.html)の更新はこれである。
 
 ```
-&lt;script id="2d-vertex-shader" type="x-shader/x-vertex"&gt;
+<script id="2d-vertex-shader" type="x-shader/x-vertex">
 attribute vec2 a_position;
 
 uniform vec2 u_resolution;

--- a/webgl/lessons/pl/webgl-2d-rotation.md
+++ b/webgl/lessons/pl/webgl-2d-rotation.md
@@ -20,7 +20,7 @@ Będziemy mnożyć przez współrzędne X i Y punktu na okręgu jednostkowym geo
 Poniżej są aktualizacje wymagane dla naszego cieniowania.
 
 <pre class="prettyprint showlinemods">
-&lt;script id="2d-vertex-shader" type="x-shader/x-vertex"&gt;
+<script id="2d-vertex-shader" type="x-shader/x-vertex">
 attribute vec2 a_position;
 
 uniform vec2 u_resolution;

--- a/webgl/lessons/pl/webgl-2d-translation.md
+++ b/webgl/lessons/pl/webgl-2d-translation.md
@@ -86,7 +86,7 @@ Istnieje prostsza droga. Zwyczajnie wgrać tą geometrię i wykonać przesunięc
 Oto nowe cieniowanie:
 
 <pre class="prettyprint showlinemods">
-&lt;script id="2d-vertex-shader" type="x-shader/x-vertex"&gt;
+<script id="2d-vertex-shader" type="x-shader/x-vertex">
 attribute vec2 a_position;
 
 uniform vec2 u_resolution;

--- a/webgl/lessons/ru/webgl-2d-scale.md
+++ b/webgl/lessons/ru/webgl-2d-scale.md
@@ -10,7 +10,7 @@ Description: Как выполнить масштабирование в 2D
 сравнению с [предыдущей статьёй](webgl-2d-rotation.html).
 
 ```
-&lt;script id="2d-vertex-shader" type="x-shader/x-vertex"&gt;
+<script id="2d-vertex-shader" type="x-shader/x-vertex">
 attribute vec2 a_position;
 
 uniform vec2 u_resolution;

--- a/webgl/lessons/ru/webgl-2d-translation.md
+++ b/webgl/lessons/ru/webgl-2d-translation.md
@@ -140,7 +140,7 @@ function setGeometry(gl, x, y) {
 Так будет выглядеть шейдер:
 
 ```
-&lt;script id="2d-vertex-shader" type="x-shader/x-vertex"&gt;
+<script id="2d-vertex-shader" type="x-shader/x-vertex">
 attribute vec2 a_position;
 
 uniform vec2 u_resolution;

--- a/webgl/lessons/webgl-2d-translation.md
+++ b/webgl/lessons/webgl-2d-translation.md
@@ -140,7 +140,7 @@ the shader.
 Here's the new shader
 
 ```
-&lt;script id="2d-vertex-shader" type="x-shader/x-vertex"&gt;
+<script id="2d-vertex-shader" type="x-shader/x-vertex">
 attribute vec2 a_position;
 
 uniform vec2 u_resolution;

--- a/webgl/lessons/zh_cn/webgl-2d-translation.md
+++ b/webgl/lessons/zh_cn/webgl-2d-translation.md
@@ -126,7 +126,7 @@ function setGeometry(gl, x, y) {
 这是新的着色器
 
 ```
-&lt;script id="2d-vertex-shader" type="x-shader/x-vertex"&gt;
+<script id="2d-vertex-shader" type="x-shader/x-vertex">
 attribute vec2 a_position;
 
 uniform vec2 u_resolution;


### PR DESCRIPTION
Fix escaped `<` and `>` characters of the `<script>` tag in WebGL 2D Translation page (shader code example): https://webglfundamentals.org/webgl/lessons/webgl-2d-translation.html

before:

<img width="1100" alt="before" src="https://user-images.githubusercontent.com/911894/47140319-1caac780-d2e8-11e8-8961-8284a56b1ffa.png">

after:

<img width="1095" alt="after" src="https://user-images.githubusercontent.com/911894/47140340-2d5b3d80-d2e8-11e8-8637-632105727804.png">

👀 
